### PR TITLE
Update tr command

### DIFF
--- a/kubectl-node_shell
+++ b/kubectl-node_shell
@@ -6,7 +6,7 @@ fi
 
 NODE="$1"
 IMAGE="alpine"
-POD="nsenter-$(env LC_CTYPE=C tr -dc a-z0-9 < /dev/urandom | head -c 6)"
+9 POD="nsenter-$(env LC_ALL=C tr -dc a-z0-9 < /dev/urandom | head -c 6)"
 NAMESPACE=""
 
 # Check the node

--- a/kubectl-node_shell
+++ b/kubectl-node_shell
@@ -6,7 +6,7 @@ fi
 
 NODE="$1"
 IMAGE="alpine"
-9 POD="nsenter-$(env LC_ALL=C tr -dc a-z0-9 < /dev/urandom | head -c 6)"
+POD="nsenter-$(env LC_ALL=C tr -dc a-z0-9 < /dev/urandom | head -c 6)"
 NAMESPACE=""
 
 # Check the node


### PR DESCRIPTION
I was receiving this tr error on macOS:
```
╰─ k node-shell ip-10-50-24-196.ec2.internal
tr: Illegal byte sequence
```

So I updated the pod command to use `LC_ALL=C`.