### PR TITLE
fix: Use FQDN for docker hub registry

### DIFF
--- a/kubectl-node_shell
+++ b/kubectl-node_shell
@@ -5,7 +5,7 @@ if [ -z "$1" ]; then
 fi
 
 NODE="$1"
-IMAGE="alpine"
+IMAGE="docker.io/library/alpine"
 POD="nsenter-$(env LC_ALL=C tr -dc a-z0-9 < /dev/urandom | head -c 6)"
 NAMESPACE=""
 
@@ -36,4 +36,4 @@ EOT
 )"
 
 echo "spawning \"$POD\" on \"$NODE\""
-kubectl run --namespace "$NAMESPACE" --rm --image alpine --overrides="$OVERRIDES" --generator=run-pod/v1 -ti "$POD"
+kubectl run --namespace "$NAMESPACE" --rm --image "$IMAGE" --overrides="$OVERRIDES" --generator=run-pod/v1 -ti "$POD"


### PR DESCRIPTION
When using CRIO in the default configuration image names must be fully qualified, or you get `Failed to inspect image "alpine": rpc error: code = Unknown desc = no registries configured while trying to pull an unqualified image, add at least one in either /etc/crio/crio.conf or /etc/containers/registries.conf`