### PR TITLE
Now able to exec into a specific nodepool

### DIFF
--- a/kubectl-node_shell
+++ b/kubectl-node_shell
@@ -28,18 +28,13 @@ while [ $# -gt 0 ]; do
       cat <<EOT
 "tolerations": [
   {
-    "key": "$cluster.node.taint", 
-    "operator": "Equal",
-    "value": "$2",
+    "operator": "Exists",
     "effect": "NoExecute"
   }
 ],
-"nodeSelector": {
-  "$cluster.node.label": "$2"
-},
 EOT
 )"
-  shift 2
+  shift
   ;;
   *)
     node="$1"

--- a/kubectl-node_shell
+++ b/kubectl-node_shell
@@ -39,7 +39,6 @@ while [ $# -gt 0 ]; do
 },
 EOT
 )"
-echo $taint
   shift 2
   ;;
   *)

--- a/kubectl-node_shell
+++ b/kubectl-node_shell
@@ -5,25 +5,43 @@ kubeconfig=""
 generator=""
 node=""
 namespace=""
+taint=""
 while [ $# -gt 0 ]; do
   key="$1"
 
   case $key in
   --context)
     context="--context $2"
-    shift
-    shift
+    shift 2
     ;;
   --kubeconfig)
     kubeconfig="--kubeconfig $2"
-    shift
-    shift
+    shift 2
     ;;
   -n | --namespace)
     namespace="--namespace $2"
-    shift
-    shift
+    shift 2
     ;;
+  --taint)
+    cluster=$(kubectl config current-context)
+    taint="$(
+      cat <<EOT
+"tolerations": [
+  {
+    "key": "$cluster.node.taint", 
+    "operator": "Equal",
+    "value": "$2",
+    "effect": "NoExecute"
+  }
+],
+"nodeSelector": {
+  "$cluster.node.label": "$2"
+},
+EOT
+)"
+echo $taint
+  shift 2
+  ;;
   *)
     node="$1"
     shift
@@ -46,6 +64,7 @@ overrides="$(
   cat <<EOT
 {
   "spec": {
+    $taint
     "nodeName": "$node",
     "hostPID": true,
     "containers": [


### PR DESCRIPTION
On our cluster we have nodepools for certain applications only. This command wasn't allowed to spawn a pod on those nodes because they were looking for specific toleration/node selector. I've added the ability to specify a `--taint` followed by the word that denotes your nodepool. 

I've also cleaned up the double shifting because you can just add a number for how much you want to shift by..