### PR TITLE
Enable support for custom image (#19)

### DIFF
--- a/kubectl-node_shell
+++ b/kubectl-node_shell
@@ -84,7 +84,7 @@ if [ -z "$node" ]; then
   exit 1
 fi
 
-image="docker.io/library/alpine"
+image="${KUBECTL_NODE_SHELL_IMAGE:-docker.io/library/alpine}"
 pod="nsenter-$(env LC_ALL=C tr -dc a-z0-9 </dev/urandom | head -c 6)"
 
 # Check the node


### PR DESCRIPTION
This PR enables support for customizing the image used in the deployed pod. For our case, we are getting rate limited by Docker Hub, and wish to use an internal proxied image. Usage looks like this:
```
export KUBECTL_NODE_SHELL_IMAGE=some_custom_image
kubectl node-shell [node] # as usual
```