### PR TITLE
Add the possibility to run the script from inside a cluster and select random node when no one is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
 # kubectl node-shell
 *(formerly known as **kubectl-enter**)*
 
+
 Start a root shell in the node's host OS running.
 
 ![demo](https://gist.githubusercontent.com/kvaps/2e3d77975a844654ec297893e21a0829/raw/c778a8405ff8c686e4e807a97e9721b423e7208f/kubectl-node-shell.gif)
+
+## My fork
+
+This is a fork of https://github.com/kvaps/kubectl-node-shell to add two
+functionalities:
+- Be able to use the script from inside a pod (i.e. with a service account
+  token mounted and no kubeconfig).
+- Select a random node when you don't specify it in the command line (because
+  often, roles tied to service account have no specific permissions about
+  nodes).
 
 ## Installation
 

--- a/kubectl-node_shell
+++ b/kubectl-node_shell
@@ -4,8 +4,10 @@ set -e
 kubectl=kubectl
 generator=""
 node=""
+nodenameinsert=""
 nodefaultctx=0
 nodefaultns=0
+nonodecheck=0
 cmd=(nsenter --target 1 --mount --uts --ipc --net --pid --)
 custom=false
 if [ -t 0 ]; then
@@ -17,6 +19,14 @@ while [ $# -gt 0 ]; do
   key="$1"
 
   case $key in
+  --incluster)
+    nodefaultctx=1
+    nodefaultns=1
+    nonodecheck=1
+    inclusterpath="/run/secrets/kubernetes.io/serviceaccount"
+    kubectl="$kubectl --token=$(cat $inclusterpath/token) --namespace=$(cat $inclusterpath/namespace)"
+    shift
+    ;;
   --context)
     nodefaultctx=1
     kubectl="$kubectl --context $2"
@@ -81,23 +91,25 @@ cmd=( "${cmd[@]//\'/\"}" )
 entrypoint="$(echo "['${cmd[@]/%/\', \'}']" | sed -e "s/' /'/g" \
                    -e "s/, '']\$/]/" -Ee "s/([\"\\])/\\\\\1/g" -e 's/\\\\n/\\n/g' | tr \' \")"
 
+nodenameinsert="\"nodeName\": \"$node\","
 if [ -z "$node" ]; then
-  echo "Please specify node name"
-  exit 1
+  echo "No node name was specified, selecting random node"
+  nonodecheck=1
+  nodenameinsert=''
 fi
 
 image="${KUBECTL_NODE_SHELL_IMAGE:-docker.io/library/alpine}"
 pod="nsenter-$(env LC_ALL=C tr -dc a-z0-9 </dev/urandom | head -c 6)"
 
 # Check the node
-$kubectl get node "$node" >/dev/null || exit 1
+[ "$nonodecheck" = 1 ] || $kubectl get node "$node" >/dev/null || exit 1
 
 overrides="$(
   cat <<EOT
 {
   "spec": {
-    "nodeName": "$node",
     "hostPID": true,
+    $nodenameinsert
     "hostNetwork": true,
     "containers": [
       {
@@ -135,5 +147,9 @@ fi
 
 trap "EC=\$?; $kubectl delete pod --wait=false $pod >&2 || true; exit \$EC" EXIT INT TERM
 
-echo "spawning \"$pod\" on \"$node\"" >&2
+if [ -z "$node" ]; then
+  echo "spawning \"$pod\" on a random node" >&2
+else
+  echo "spawning \"$pod\" on \"$node\"" >&2
+fi
 $kubectl run --image "$image" --restart=Never --overrides="$overrides"  $([ -t 0 ] && echo -t) -i "$pod" $generator


### PR DESCRIPTION
First I want to say: thanks a lot for your work, your script is really elegant as an issue already states!

I just tweaked your script for my use case (which is maybe too specific), and I wanted to propose my changes, even if I understand that they do not follow the philosophy of the project, which was just an administration tool I guess (and in this case, it might seem crazy to select a random node)! So really feel free to close this PR I'll understand or maybe discuss it further if you are ever interested in the added features. I just wanted to propose them because your script helped me a lot.

I just wanted to add the following functionalities (unfortunately both features are in the same commit):
- be able to use the script from a pod's perspective (with a service account token mounted and no kubeconfig).
- select a random node when you don't specify it in the command line (because often, roles tied to service account have no specific permissions about nodes).