### PR TITLE
allow for node/$nodename resource form

### DIFF
--- a/kubectl-node_shell
+++ b/kubectl-node_shell
@@ -58,7 +58,7 @@ while [ $# -gt 0 ]; do
     ;;
   *)
     if [ -z "$node" ]; then
-      node="$(echo $1 | sed 's/^node\///')"
+      node="${1#node/}"
       shift
     else
       echo "exactly one node required"

--- a/kubectl-node_shell
+++ b/kubectl-node_shell
@@ -58,7 +58,7 @@ while [ $# -gt 0 ]; do
     ;;
   *)
     if [ -z "$node" ]; then
-      node="$1"
+      node="$(echo $1 | sed 's/^node\///')"
       shift
     else
       echo "exactly one node required"

--- a/kubectl-node_shell
+++ b/kubectl-node_shell
@@ -2,7 +2,7 @@
 set -e
 
 kubectl=kubectl
-version=1.5.3
+version=1.5.4
 generator=""
 node=""
 nodefaultctx=0


### PR DESCRIPTION
I sometimes use this plugin with a `for node in $(kubectl get names -o node); do kubectl node-shell "$node" -- something` loop. The kubectl get names -o node outputs a list of nodenames prefixed with the `node/` type.
This change will, always, simply filter out `node/` at the beginning of the node name.