### PR TITLE
Add support for Windows nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # kubectl node-shell
 *(formerly known as **kubectl-enter**)*
 
-Start a root shell in the node's host OS running.
+Start a root shell in the node's host OS running. Uses an alpine pod with nsenter for Linux nodes and a [HostProcess pod](https://kubernetes.io/docs/tasks/configure-pod-container/create-hostprocess-pod/) with PowerShell for Windows nodes.
 
 ![demo](https://gist.githubusercontent.com/kvaps/2e3d77975a844654ec297893e21a0829/raw/c778a8405ff8c686e4e807a97e9721b423e7208f/kubectl-node-shell.gif)
 

--- a/kubectl-node_shell
+++ b/kubectl-node_shell
@@ -90,23 +90,23 @@ if [ "$os" = "windows" ]; then
   pod="${name}-$(env LC_ALL=C tr -dc a-z0-9 </dev/urandom | head -c 6)"
   # pwsh has to be launched via cmd.exe because of how containerd 1.6 handles the mount of the container filesystem
   # see https://kubernetes.io/docs/tasks/configure-pod-container/create-hostprocess-pod/#volume-mounts
-  cmdStart='"cmd.exe", "/c", "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\PowerShell\\latest\\pwsh.exe", "-nol", "-wd", "C:\\"'
-  cmdArgPrefix=', "-Command"'
-  cmdDefault=''
-  securityContext='{"privileged":true,"windowsOptions":{"hostProcess":true,"runAsUserName":"NT AUTHORITY\\SYSTEM"}}'
+  cmd_start='"cmd.exe", "/c", "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\PowerShell\\latest\\pwsh.exe", "-nol", "-wd", "C:\\"'
+  cmd_arg_prefix=', "-Command"'
+  cmd_default=''
+  security_context='{"privileged":true,"windowsOptions":{"hostProcess":true,"runAsUserName":"NT AUTHORITY\\SYSTEM"}}'
 else # If the OS isn't windows, assume linux
   image="${KUBECTL_NODE_SHELL_IMAGE:-docker.io/library/alpine}"
   name="nsenter"
   pod="${name}-$(env LC_ALL=C tr -dc a-z0-9 </dev/urandom | head -c 6)"
-  cmdStart='"nsenter", "--target", "1", "--mount", "--uts", "--ipc", "--net", "--pid"'
-  cmdArgPrefix=', "--"'
-  cmdDefault=', "bash", "-l"'
-  securityContext='{"privileged":true}'
+  cmd_start='"nsenter", "--target", "1", "--mount", "--uts", "--ipc", "--net", "--pid"'
+  cmd_arg_prefix=', "--"'
+  cmd_default=', "bash", "-l"'
+  security_context='{"privileged":true}'
 fi
 
 # Build the container command
 if [ $# -gt 0 ]; then
-  cmd="[ $cmdStart $cmdArgPrefix"
+  cmd="[ $cmd_start $cmd_arg_prefix"
   while [ $# -gt 0 ]; do
     cmd="$cmd, \"$(echo "$1" | \
       awk '{gsub(/["\\]/,"\\\\&");gsub(/\x1b/,"\\u001b");printf "%s",last;last=$0"\\n"} END{print $0}' \
@@ -115,7 +115,7 @@ if [ $# -gt 0 ]; then
   done
   cmd="$cmd ]"
 else
-  cmd="[ $cmdStart $cmdDefault ]"
+  cmd="[ $cmd_start $cmd_default ]"
 fi
 
 overrides="$(
@@ -127,7 +127,7 @@ cat <<EOT
     "hostNetwork": true,
     "containers": [
       {
-        "securityContext": $securityContext,
+        "securityContext": $security_context,
         "image": "$image",
         "name": "$name",
         "stdin": true,

--- a/kubectl-node_shell
+++ b/kubectl-node_shell
@@ -2,12 +2,19 @@
 set -e
 
 kubectl=kubectl
-version=1.5.5
+version=1.6.0
 generator=""
 node=""
 nodefaultctx=0
 nodefaultns=0
-cmd='[ "nsenter", "--target", "1", "--mount", "--uts", "--ipc", "--net", "--pid", "--"'
+
+cmd_windows='[ "powershell.exe"'
+cmd_linux='[ "nsenter", "--target", "1", "--mount", "--uts", "--ipc", "--net", "--pid", "--"'
+image_linux="${KUBECTL_NODE_SHELL_IMAGE:-docker.io/library/alpine}"
+image_windows="${KUBECTL_NODE_SHELL_WINDOWS:-mcr.microsoft.com/powershell}"
+pod_linux="nsenter-$(env LC_ALL=C tr -dc a-z0-9 </dev/urandom | head -c 6)"
+pod_windows="pwsh-$(env LC_ALL=C tr -dc a-z0-9 </dev/urandom | head -c 6)"
+
 if [ -t 0 ]; then
   tty=true
 else
@@ -72,34 +79,103 @@ done
 [ "$nodefaultctx" = 1 ] || kubectl="$kubectl --context=$(${kubectl} config current-context)"
 [ "$nodefaultns" = 1 ] || kubectl="$kubectl --namespace=$(${kubectl} config view --minify --output 'jsonpath={.contexts..namespace}')"
 
-if [ $# -gt 0 ]; then
-  while [ $# -gt 0 ]; do
-    cmd="$cmd, \"$(echo "$1" | \
-      awk '{gsub(/["\\]/,"\\\\&");gsub(/\x1b/,"\\u001b");printf "%s",last;last=$0"\\n"} END{print $0}' \
-    )\""
-    shift
-  done
-  cmd="$cmd ]"
-else
-  cmd="$cmd, \"bash\", \"-l\" ]"
-fi
-
 if [ -z "$node" ]; then
   echo "Please specify node name"
   exit 1
 fi
 
-image="${KUBECTL_NODE_SHELL_IMAGE:-docker.io/library/alpine}"
-pod="nsenter-$(env LC_ALL=C tr -dc a-z0-9 </dev/urandom | head -c 6)"
-
 # Check the node
 $kubectl get node "$node" >/dev/null || exit 1
+os="$($kubectl get node $node -o jsonpath="{.metadata.labels.kubernetes\.io/os}")"
 
 container_cpu="${KUBECTL_NODE_SHELL_POD_CPU:-100m}"
 container_memory="${KUBECTL_NODE_SHELL_POD_MEMORY:-256Mi}"
 labels="${KUBECTL_NODE_SHELL_LABELS}"
 
-overrides="$(
+
+if [ "$os" = "windows" ]; then
+  cmd="$cmd_windows"
+  image="$image_windows"
+  pod="$pod_windows"
+
+  if [ $# -gt 0 ]; then
+    while [ $# -gt 0 ]; do
+      cmd="$cmd, \"$(echo "$1" | \
+        awk '{gsub(/["\\]/,"\\\\&");gsub(/\x1b/,"\\u001b");printf "%s",last;last=$0"\\n"} END{print $0}' \
+      )\""
+      shift
+    done
+  fi
+  cmd="$cmd ]"
+
+  overrides="$(
+    cat <<EOT
+{
+  "spec": {
+    "nodeName": "$node",
+    "hostPID": true,
+    "hostNetwork": true,
+    "containers": [
+      {
+        "securityContext": {
+          "privileged": true,
+          "windowsOptions": {
+            "hostProcess": true,
+            "runAsUserName": "NT AUTHORITY\\\\SYSTEM"
+          }
+        },
+        "image": "$image_windows",
+        "name": "powershell",
+        "stdin": true,
+        "stdinOnce": true,
+        "tty": $tty,
+        "command": $cmd,
+        "workingDir": "C:\\\\",
+        "resources": {
+          "limits": {
+            "cpu": "${container_cpu}",
+            "memory": "${container_memory}"
+          },
+          "requests": {
+            "cpu": "${container_cpu}",
+            "memory": "${container_memory}"
+          }
+        }
+      }
+    ],
+    "tolerations": [
+      {
+        "key": "CriticalAddonsOnly",
+        "operator": "Exists"
+      },
+      {
+        "effect": "NoExecute",
+        "operator": "Exists"
+      }
+    ]
+  }
+}
+EOT
+  )"
+  echo "$overrides"
+else
+  cmd="$cmd_linux"
+  image="$image_linux"
+  pod="$pod_linux"
+
+  if [ $# -gt 0 ]; then
+    while [ $# -gt 0 ]; do
+      cmd="$cmd, \"$(echo "$1" | \
+        awk '{gsub(/["\\]/,"\\\\&");gsub(/\x1b/,"\\u001b");printf "%s",last;last=$0"\\n"} END{print $0}' \
+      )\""
+      shift
+    done
+    cmd="$cmd ]"
+  else
+    cmd="$cmd, \"bash\", \"-l\" ]"
+  fi
+
+  overrides="$(
   cat <<EOT
 {
   "spec": {
@@ -111,7 +187,7 @@ overrides="$(
         "securityContext": {
           "privileged": true
         },
-        "image": "$image",
+        "image": "$image_linux",
         "name": "nsenter",
         "stdin": true,
         "stdinOnce": true,
@@ -142,7 +218,8 @@ overrides="$(
   }
 }
 EOT
-)"
+  )"
+fi
 
 # Support Kubectl <1.18
 m=$(kubectl version --client -o yaml | awk -F'[ :"]+' '$2 == "minor" {print $3+0}')

--- a/kubectl-node_shell
+++ b/kubectl-node_shell
@@ -2,18 +2,14 @@
 set -e
 
 kubectl=kubectl
-version=1.6.0
+version=1.7.0
 generator=""
 node=""
 nodefaultctx=0
 nodefaultns=0
-
-cmd_windows='[ "powershell.exe"'
-cmd_linux='[ "nsenter", "--target", "1", "--mount", "--uts", "--ipc", "--net", "--pid", "--"'
-image_linux="${KUBECTL_NODE_SHELL_IMAGE:-docker.io/library/alpine}"
-image_windows="${KUBECTL_NODE_SHELL_WINDOWS:-mcr.microsoft.com/powershell}"
-pod_linux="nsenter-$(env LC_ALL=C tr -dc a-z0-9 </dev/urandom | head -c 6)"
-pod_windows="pwsh-$(env LC_ALL=C tr -dc a-z0-9 </dev/urandom | head -c 6)"
+container_cpu="${KUBECTL_NODE_SHELL_POD_CPU:-100m}"
+container_memory="${KUBECTL_NODE_SHELL_POD_MEMORY:-256Mi}"
+labels="${KUBECTL_NODE_SHELL_LABELS}"
 
 if [ -t 0 ]; then
   tty=true
@@ -75,151 +71,83 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-# Set the default context and namespace to avoid situations where the user switch them during the build process
-[ "$nodefaultctx" = 1 ] || kubectl="$kubectl --context=$(${kubectl} config current-context)"
-[ "$nodefaultns" = 1 ] || kubectl="$kubectl --namespace=$(${kubectl} config view --minify --output 'jsonpath={.contexts..namespace}')"
-
 if [ -z "$node" ]; then
   echo "Please specify node name"
   exit 1
 fi
 
-# Check the node
-$kubectl get node "$node" >/dev/null || exit 1
-os="$($kubectl get node $node -o jsonpath="{.metadata.labels.kubernetes\.io/os}")"
+# Set the default context and namespace to avoid situations where the user switch them during the build process
+[ "$nodefaultctx" = 1 ] || kubectl="$kubectl --context=$(${kubectl} config current-context)"
+[ "$nodefaultns" = 1 ] || kubectl="$kubectl --namespace=$(${kubectl} config view --minify --output 'jsonpath={.contexts..namespace}')"
 
-container_cpu="${KUBECTL_NODE_SHELL_POD_CPU:-100m}"
-container_memory="${KUBECTL_NODE_SHELL_POD_MEMORY:-256Mi}"
-labels="${KUBECTL_NODE_SHELL_LABELS}"
+# Check the node and retrieve the node OS label
+os="$($kubectl get node $node -o jsonpath="{.metadata.labels.kubernetes\.io/os}" || exit 1)"
 
-
+# Set pod configuration per operating system
 if [ "$os" = "windows" ]; then
-  cmd="$cmd_windows"
-  image="$image_windows"
-  pod="$pod_windows"
-
-  if [ $# -gt 0 ]; then
-    while [ $# -gt 0 ]; do
-      cmd="$cmd, \"$(echo "$1" | \
-        awk '{gsub(/["\\]/,"\\\\&");gsub(/\x1b/,"\\u001b");printf "%s",last;last=$0"\\n"} END{print $0}' \
-      )\""
-      shift
-    done
-  fi
-  cmd="$cmd ]"
-
-  overrides="$(
-    cat <<EOT
-{
-  "spec": {
-    "nodeName": "$node",
-    "hostPID": true,
-    "hostNetwork": true,
-    "containers": [
-      {
-        "securityContext": {
-          "privileged": true,
-          "windowsOptions": {
-            "hostProcess": true,
-            "runAsUserName": "NT AUTHORITY\\\\SYSTEM"
-          }
-        },
-        "image": "$image_windows",
-        "name": "powershell",
-        "stdin": true,
-        "stdinOnce": true,
-        "tty": $tty,
-        "command": $cmd,
-        "workingDir": "C:\\\\",
-        "resources": {
-          "limits": {
-            "cpu": "${container_cpu}",
-            "memory": "${container_memory}"
-          },
-          "requests": {
-            "cpu": "${container_cpu}",
-            "memory": "${container_memory}"
-          }
-        }
-      }
-    ],
-    "tolerations": [
-      {
-        "key": "CriticalAddonsOnly",
-        "operator": "Exists"
-      },
-      {
-        "effect": "NoExecute",
-        "operator": "Exists"
-      }
-    ]
-  }
-}
-EOT
-  )"
-  echo "$overrides"
-else
-  cmd="$cmd_linux"
-  image="$image_linux"
-  pod="$pod_linux"
-
-  if [ $# -gt 0 ]; then
-    while [ $# -gt 0 ]; do
-      cmd="$cmd, \"$(echo "$1" | \
-        awk '{gsub(/["\\]/,"\\\\&");gsub(/\x1b/,"\\u001b");printf "%s",last;last=$0"\\n"} END{print $0}' \
-      )\""
-      shift
-    done
-    cmd="$cmd ]"
-  else
-    cmd="$cmd, \"bash\", \"-l\" ]"
-  fi
-
-  overrides="$(
-  cat <<EOT
-{
-  "spec": {
-    "nodeName": "$node",
-    "hostPID": true,
-    "hostNetwork": true,
-    "containers": [
-      {
-        "securityContext": {
-          "privileged": true
-        },
-        "image": "$image_linux",
-        "name": "nsenter",
-        "stdin": true,
-        "stdinOnce": true,
-        "tty": $tty,
-        "command": $cmd,
-        "resources": {
-          "limits": {
-            "cpu": "${container_cpu}",
-            "memory": "${container_memory}"
-          },
-          "requests": {
-            "cpu": "${container_cpu}",
-            "memory": "${container_memory}"
-          }
-        }
-      }
-    ],
-    "tolerations": [
-      {
-        "key": "CriticalAddonsOnly",
-        "operator": "Exists"
-      },
-      {
-        "effect": "NoExecute",
-        "operator": "Exists"
-      }
-    ]
-  }
-}
-EOT
-  )"
+  image="${KUBECTL_NODE_SHELL_IMAGE_WINDOWS:-mcr.microsoft.com/powershell}"
+  name="pwsh"
+  pod="${name}-$(env LC_ALL=C tr -dc a-z0-9 </dev/urandom | head -c 6)"
+  # pwsh has to be launched via cmd.exe because of how containerd 1.6 handles the mount of the container filesystem
+  # see https://kubernetes.io/docs/tasks/configure-pod-container/create-hostprocess-pod/#volume-mounts
+  cmdStart='"cmd.exe", "/c", "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\PowerShell\\latest\\pwsh.exe", "-nol", "-wd", "C:\\"'
+  cmdArgPrefix=', "-Command"'
+  cmdDefault=''
+  securityContext='{"privileged":true,"windowsOptions":{"hostProcess":true,"runAsUserName":"NT AUTHORITY\\SYSTEM"}}'
+else # If the OS isn't windows, assume linux
+  image="${KUBECTL_NODE_SHELL_IMAGE:-docker.io/library/alpine}"
+  name="nsenter"
+  pod="${name}-$(env LC_ALL=C tr -dc a-z0-9 </dev/urandom | head -c 6)"
+  cmdStart='"nsenter", "--target", "1", "--mount", "--uts", "--ipc", "--net", "--pid"'
+  cmdArgPrefix=', "--"'
+  cmdDefault=', "bash", "-l"'
+  securityContext='{"privileged":true}'
 fi
+
+# Build the container command
+if [ $# -gt 0 ]; then
+  cmd="[ $cmdStart $cmdArgPrefix"
+  while [ $# -gt 0 ]; do
+    cmd="$cmd, \"$(echo "$1" | \
+      awk '{gsub(/["\\]/,"\\\\&");gsub(/\x1b/,"\\u001b");printf "%s",last;last=$0"\\n"} END{print $0}' \
+    )\""
+    shift
+  done
+  cmd="$cmd ]"
+else
+  cmd="[ $cmdStart $cmdDefault ]"
+fi
+
+overrides="$(
+cat <<EOT
+{
+  "spec": {
+    "nodeName": "$node",
+    "hostPID": true,
+    "hostNetwork": true,
+    "containers": [
+      {
+        "securityContext": $securityContext,
+        "image": "$image",
+        "name": "$name",
+        "stdin": true,
+        "stdinOnce": true,
+        "tty": $tty,
+        "command": $cmd,
+        "resources": {
+          "limits":   { "cpu": "${container_cpu}", "memory": "${container_memory}" },
+          "requests": { "cpu": "${container_cpu}", "memory": "${container_memory}" }
+        }
+      }
+    ],
+    "tolerations": [
+      { "key": "CriticalAddonsOnly", "operator": "Exists" },
+      { "effect": "NoExecute",       "operator": "Exists" }
+    ]
+  }
+}
+EOT
+)"
 
 # Support Kubectl <1.18
 m=$(kubectl version --client -o yaml | awk -F'[ :"]+' '$2 == "minor" {print $3+0}')


### PR DESCRIPTION
This PR adds support for Windows nodes via a [HostProcess pod](https://kubernetes.io/docs/tasks/configure-pod-container/create-hostprocess-pod/) running PowerShell 7. Doing this relatively cleanly took a little rearranging because certain values needed to be changed based on which operating system was on the node. Whether the node is windows is determined by checking the `kubernetes.io/os` label on the node object - it defaults back to Linux (with unchanged behavior) unless that label exists and is equal to `windows`, so this shouldn't cause problems for existing users.

This will work on Kubernetes clusters of at least version 1.23 (where HostProcess containers went beta) with nodes running Windows Server 2019 or Windows Server 2022.

I changed the version in the script to 1.7.0 as a best guess, but obviously feel free to modify as needed.