### PR TITLE
Automatically set or not set resource quota through the cluster

### DIFF
--- a/kubectl-node_shell
+++ b/kubectl-node_shell
@@ -141,18 +141,11 @@ else
 fi
 
 # test if resource specification is required
-set +e
-$kubectl run test --image test --dry-run=server 2>&1 | grep 'failed quota' --quiet
-if [ $? -eq 0 ];then
-  resources_json='"resources": {
+resources_json='"resources": {
           "limits":   { "cpu": "'${container_cpu}'", "memory": "'${container_memory}'" },
           "requests": { "cpu": "'${container_cpu}'", "memory": "'${container_memory}'" }
         }'
-else
-  resources_json='"resources": {}'
-
-fi
-set -e
+$kubectl run test --image test --dry-run=server 2>&1 | grep 'failed quota' --quiet || resources_json='"resources": {}'
 
 overrides="$(
 cat <<EOT

--- a/kubectl-node_shell
+++ b/kubectl-node_shell
@@ -142,7 +142,7 @@ fi
 
 # test if resource specification is required
 set +e
-$kubectl run test --image test --dry-run=server 2>&1|grep forbidden --quiet
+$kubectl run test --image test --dry-run=server 2>&1 | grep 'failed quota' --quiet
 if [ $? -eq 0 ];then
   resources_json='"resources": {
           "limits":   { "cpu": "'${container_cpu}'", "memory": "'${container_memory}'" },

--- a/kubectl-node_shell
+++ b/kubectl-node_shell
@@ -7,6 +7,7 @@ generator=""
 node=""
 nodefaultctx=0
 nodefaultns=0
+container_cpu="${KUBECTL_NODE_SHELL_POD_CPU:-100m}"
 container_memory="${KUBECTL_NODE_SHELL_POD_MEMORY:-256Mi}"
 volumes="[]"
 volume_mounts="[]"
@@ -139,6 +140,20 @@ else
   fi
 fi
 
+# test if resource specification is required
+set +e
+$kubectl run test --image test --dry-run=server 2>&1|grep forbidden --quiet
+if [ $? -eq 0 ];then
+  resources_json='"resources": {
+          "limits":   { "cpu": "'${container_cpu}'", "memory": "'${container_memory}'" },
+          "requests": { "cpu": "'${container_cpu}'", "memory": "'${container_memory}'" }
+        }'
+else
+  resources_json='"resources": {}'
+
+fi
+set -e
+
 overrides="$(
 cat <<EOT
 {
@@ -155,10 +170,7 @@ cat <<EOT
         "stdinOnce": true,
         "tty": $tty,
         "command": $cmd,
-        "resources": {
-          "limits":   { "memory": "${container_memory}" },
-          "requests": { "memory": "${container_memory}" }
-        },
+        $resources_json,
         "volumeMounts": $volume_mounts
       }
     ],
@@ -171,7 +183,6 @@ cat <<EOT
 }
 EOT
 )"
-
 # Support Kubectl <1.18
 m=$(kubectl version --client -o yaml | awk -F'[ :"]+' '$2 == "minor" {print $3+0}')
 if [ "$m" -lt 18 ]; then

--- a/kubectl-node_shell
+++ b/kubectl-node_shell
@@ -7,7 +7,6 @@ generator=""
 node=""
 nodefaultctx=0
 nodefaultns=0
-container_cpu="${KUBECTL_NODE_SHELL_POD_CPU:-100m}"
 container_memory="${KUBECTL_NODE_SHELL_POD_MEMORY:-256Mi}"
 volumes="[]"
 volume_mounts="[]"
@@ -157,8 +156,8 @@ cat <<EOT
         "tty": $tty,
         "command": $cmd,
         "resources": {
-          "limits":   { "cpu": "${container_cpu}", "memory": "${container_memory}" },
-          "requests": { "cpu": "${container_cpu}", "memory": "${container_memory}" }
+          "limits":   { "memory": "${container_memory}" },
+          "requests": { "memory": "${container_memory}" }
         },
         "volumeMounts": $volume_mounts
       }


### PR DESCRIPTION
CRI-O 1.28 no longer supports CGOUP1 for CPU allocation when use centos7, In order to be compatible, we should remove the CPU restrictions in the script.
#53 