### PR TITLE
qfix readme.md and add tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ sudo mv ./kubectl-node_shell /usr/local/bin/kubectl-node_shell
 # Get standard bash shell
 kubectl node-shell <node>
 
+# Use custom image for pod
+kubectl node-shell <node> --image <image>
+
 # Use X-mode (mount /host, and do not enter host namespace)
 kubectl node-shell -x <node>
 


### PR DESCRIPTION
New information about the plugin image flag has just been added. I would also add  **_v1.10.2 tag_**, since new features were added before that, and krew does not see them in the repository.